### PR TITLE
Add GSoC 2018 student blogs

### DIFF
--- a/openmrs-planet.ini
+++ b/openmrs-planet.ini
@@ -171,7 +171,7 @@ name = Zakaria Amine
 [http://yousefhamza.github.io/feed.xml]
 name = Yousef Hamza
 
-[https://milankarunarathne.wordpress.com/feed/]
+[https://milankarunarathne.wordpress.com/tag/openmrs/feed/]
 name = Milan Karunarathne
 
 [https://tharunyareddy.wordpress.com/feed/]
@@ -261,3 +261,33 @@ name = Kwateng Ofori
 
 [https://sanatt.me/feed/]
 name = Sanatt Abrol
+
+[https://fanyui.blogspot.com/feeds/posts/default]
+name = Harisu Fanyui
+
+[https://medium.com/feed/@amoh.eunice/]
+name = Eunice Amoh
+
+[https://easyprogramminglk.blogspot.com/feeds/posts/default/-/openmrs]
+name = Chathuranga Muthukuda
+
+[https://prabodhgsoc2018.wordpress.com/feed/]
+name = Prabodh Kotasthane
+
+[https://medium.com/feed/@isurangamperera/]
+name = Isuranga Perera
+
+[https://medium.com/feed/@R.Sumangala/]
+name = Jeyasumangala Rasanayagam
+
+[https://medium.com/feed/@ridmalmadushanka/]
+name = Ridmal	Liyanagamge
+
+[https://medium.com/feed/@dilekamadushan/]
+name = Dileka Weerasuriya
+
+[https://malesamuel34.blogspot.com/feeds/posts/default]
+name = Samuel Male
+
+[https://medium.com/feed/piyush-kundnani/]
+name = Piyush Kundnani


### PR DESCRIPTION
Added list of GSoC 2018 student blogs, limit feeds to 'openmrs' tag/label where available.